### PR TITLE
Setup CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+env:
+  global:
+    - LC_CTYPE=en_US.UTF-8
+    - SWIFT_VERSION=2018-10-17
+matrix:
+  include:
+    - os: osx
+      language: objective-c
+      osx_image: xcode10
+      before_install:
+        - curl -O "https://storage.googleapis.com/swift-tensorflow/mac/swift-tensorflow-DEVELOPMENT-${SWIFT_VERSION}-a-osx.pkg"
+        - sudo installer -pkg "swift-tensorflow-DEVELOPMENT-${SWIFT_VERSION}-a-osx.pkg" -target /
+        - export PATH="/Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-${SWIFT_VERSION}-a.xctoolchain/usr/bin:${PATH}"
+        - pip install lit
+      script:
+        - make testall

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GPIR
 
+[![Build Status](https://travis-ci.org/rxwei/GPIR.svg?branch=master)](https://travis-ci.org/rxwei/GPIR)
+
 Coming soon...
 
 ## License


### PR DESCRIPTION
Setup Travis CI using macOS with the latest S4TF toolchain.
CI runs both XCTests and FileCheck tests.

Linux is unsupported: Travis uses Ubuntu 14.04 but S4TF supports only Ubuntu 16.04 toolchains.